### PR TITLE
fix error handling so that filename / line number etc are reported properly

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,6 @@
 es         = require 'event-stream'
 ngClassify = require 'ng-classify'
+gutil      = require 'gulp-util'
 
 module.exports = (opt) ->
 	modifyFile = (file) ->
@@ -7,7 +8,7 @@ module.exports = (opt) ->
 			@emit 'data', file
 
 		return if file.isStream()
-			@emit 'error', new Error 'gulp-ngClassify: Streaming not supported'
+			@emit 'error', new gutil.PluginError 'gulp-ng-classify', 'Streaming not supported'
 
 		str = file.contents.toString 'utf8'
 		data = ''
@@ -17,7 +18,7 @@ module.exports = (opt) ->
 			options    = if isFunction then opt(file) else opt
 			data       = ngClassify str, options
 		catch err
-			return @emit 'error', new Error err
+			return @emit 'error', new gutil.PluginError 'gulp-ng-classify', err
 
 		file.contents = new Buffer data
 

--- a/index.coffee
+++ b/index.coffee
@@ -18,6 +18,7 @@ module.exports = (opt) ->
 			options    = if isFunction then opt(file) else opt
 			data       = ngClassify str, options
 		catch err
+			err.filename = file.path
 			return @emit 'error', new gutil.PluginError 'gulp-ng-classify', err
 
 		file.contents = new Buffer data


### PR DESCRIPTION
Without this change, the error that this plugin returns to the gulptask only contains the error message, but not the filename or line number, or anything useful for finding where the coffeescript syntax error occurred. 