### PR TITLE
fix(dependencies): make gulp-util dist dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
 	"dependencies": {
 		"coffee-script": "^1.7.1",
 		"event-stream": "^3.1.5",
-		"ng-classify": "^4.0.0"
+		"ng-classify": "^4.0.0",
+		"gulp-util": "^3.0.0"
 	},
 	"devDependencies": {
 		"conventional-changelog": "0.0.11",
-		"gulp": "^3.8.0",
-		"gulp-util": "^3.0.0"
+		"gulp": "^3.8.0"
 	},
 	"files": [
 		"CHANGELOG.md",


### PR DESCRIPTION
This change fixes:

> Error: Cannot find module 'gulp-util'

Because index.coffee requires it to be in dependencies, not in devDependencies:

```
gutil = require 'gulp-util'
```
